### PR TITLE
Add Material Design chat widget

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,8 @@
   <meta charset="UTF-8">
   <title>MindMate Demo Chat</title>
   <link rel="stylesheet" href="styles.css">
+  <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
 <body>
   <div id="chat">
@@ -14,5 +16,7 @@
   </div>
   <div id="scenarios"></div>
   <script src="script.js"></script>
+  <link rel="stylesheet" href="widget.css">
+  <script src="widget.js"></script>
 </body>
 </html>

--- a/public/widget.css
+++ b/public/widget.css
@@ -1,0 +1,76 @@
+#chat-widget {
+  position: fixed;
+  bottom: 16px;
+  right: 16px;
+  font-family: Roboto, Arial, sans-serif;
+  z-index: 1000;
+}
+
+#chat-fab {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  border: none;
+  background-color: #6200ea;
+  color: white;
+  box-shadow: 0 3px 6px rgba(0,0,0,0.2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform 0.3s;
+}
+#chat-fab.open { transform: rotate(45deg); }
+
+#chat-panel {
+  width: 100%;
+  max-width: 400px;
+  height: 0;
+  overflow: hidden;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 3px 8px rgba(0,0,0,0.3);
+  margin-bottom: 8px;
+  display: flex;
+  flex-direction: column;
+  transition: height 0.3s;
+}
+#chat-panel.open { height: 500px; }
+@media (max-width: 600px) {
+  #chat-panel.open {
+    height: calc(100vh - 80px);
+  }
+}
+
+#chat-messages {
+  flex: 1;
+  padding: 8px;
+  overflow-y: auto;
+}
+.msg { margin: 4px 8px; padding: 8px 12px; border-radius: 16px; max-width: 80%; }
+.msg.user { background:#e1bee7; margin-left:auto; text-align:right; }
+.msg.bot { background:#e0e0e0; }
+
+#chat-quick { padding:4px 8px; }
+#chat-quick .quick { margin:2px; }
+
+#chat-input-row {
+  display:flex;
+  border-top:1px solid #ccc;
+}
+#chat-input {
+  flex:1;
+  border:none;
+  padding:8px;
+  font-size:1em;
+  outline:none;
+}
+#chat-send {
+  border:none;
+  background:none;
+  color:#6200ea;
+  padding:0 12px;
+  cursor:pointer;
+}
+
+.material-icons { font-family: 'Material Icons'; }

--- a/public/widget.js
+++ b/public/widget.js
@@ -1,0 +1,93 @@
+// Chat widget script
+
+(function() {
+  const styleLink = document.createElement('link');
+  styleLink.rel = 'stylesheet';
+  styleLink.href = 'widget.css';
+  document.head.appendChild(styleLink);
+
+  const container = document.createElement('div');
+  container.id = 'chat-widget';
+  container.innerHTML = `
+    <button id="chat-fab" title="Помощник">
+      <span class="material-icons">chat</span>
+    </button>
+    <div id="chat-panel">
+      <div id="chat-messages"></div>
+      <div id="chat-quick"></div>
+      <div id="chat-input-row">
+        <input id="chat-input" type="text" placeholder="Введите сообщение..." />
+        <button id="chat-send"><span class="material-icons">send</span></button>
+      </div>
+    </div>`;
+  document.body.appendChild(container);
+
+  const fab = container.querySelector('#chat-fab');
+  const panel = container.querySelector('#chat-panel');
+  const messages = container.querySelector('#chat-messages');
+  const quick = container.querySelector('#chat-quick');
+  const input = container.querySelector('#chat-input');
+  const sendBtn = container.querySelector('#chat-send');
+
+  function toggleChat() {
+    panel.classList.toggle('open');
+    fab.classList.toggle('open');
+    if (panel.classList.contains('open')) {
+      input.focus();
+      scrollToBottom();
+    }
+  }
+
+  fab.addEventListener('click', toggleChat);
+
+  sendBtn.addEventListener('click', () => {
+    const text = input.value.trim();
+    if (!text) return;
+    addMessage(text, 'user');
+    input.value = '';
+    send(text);
+  });
+
+  input.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') {
+      sendBtn.click();
+    }
+  });
+
+  function addMessage(text, from) {
+    const div = document.createElement('div');
+    div.className = 'msg ' + from;
+    div.textContent = text;
+    messages.appendChild(div);
+    scrollToBottom();
+  }
+
+  function scrollToBottom() {
+    messages.scrollTop = messages.scrollHeight;
+  }
+
+  async function send(text) {
+    try {
+      const res = await fetch('/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: text })
+      });
+      const data = await res.json();
+      addMessage(data.reply, 'bot');
+      quick.innerHTML = '';
+      (data.followUps || []).forEach(t => {
+        const b = document.createElement('button');
+        b.className = 'quick';
+        b.textContent = t;
+        b.onclick = () => {
+          addMessage(t, 'user');
+          send(t);
+        };
+        quick.appendChild(b);
+      });
+    } catch (e) {
+      console.error(e);
+    }
+  }
+})();


### PR DESCRIPTION
## Summary
- add Roboto and Material Icons fonts to the demo page
- load new Material style chat widget
- implement `widget.js` for sending messages and handling quick replies
- style widget with Material-like CSS

## Testing
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_685835a1fe288321acd0e525bd9e821f