### PR TITLE
Implement loyalty intent logic

### DIFF
--- a/database/loyalty.json
+++ b/database/loyalty.json
@@ -1,5 +1,9 @@
 {
-  "balance": 650,
+  "user_id": "abc123",
+  "bonus_balance": 650,
+  "cashback_available": 120,
+  "loyalty_tier": "Gold",
+  "last_updated": "2025-06-20",
   "history": [
     {"date": "2024-01-15", "change": 200, "reason": "начисление за покупку", "products": ["Смартфон X1", "Чехол для смартфона"]},
     {"date": "2024-01-20", "change": -75, "reason": "оплата бонусами"},

--- a/public/script.js
+++ b/public/script.js
@@ -1,3 +1,5 @@
+const USER_ID = 'abc123';
+
 async function loadScenarios() {
   const res = await fetch('/api/scenarios');
   const scenarios = await res.json();
@@ -23,7 +25,7 @@ async function sendMessage(text) {
   const res = await fetch('/api/chat', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ message: text })
+    body: JSON.stringify({ message: text, userId: USER_ID })
   });
   const data = await res.json();
   addMessage(data.reply, 'bot');

--- a/public/widget.js
+++ b/public/widget.js
@@ -1,6 +1,7 @@
 // Chat widget script
 
 (function() {
+  const USER_ID = 'abc123';
   const styleLink = document.createElement('link');
   styleLink.rel = 'stylesheet';
   styleLink.href = 'widget.css';
@@ -94,7 +95,7 @@
       const res = await fetch('/api/chat', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ message: text })
+        body: JSON.stringify({ message: text, userId: USER_ID })
       });
       const data = await res.json();
       addMessage(data.reply, 'bot');

--- a/server.js
+++ b/server.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const fs = require('fs');
+const path = require('path');
 const { OpenAI } = require('openai');
 
 const app = express();
@@ -23,21 +24,86 @@ function matchScenario(input) {
   return scenarios.find(s => s.triggers.some(t => text.includes(t.toLowerCase())));
 }
 
+async function classifyScenario(text) {
+  const prompt =
+    'Ты классификатор обращений. Тебе дан JSON со сценариями. ' +
+    'Верни только поле "name" сценария, который лучше всего подходит для сообщения пользователя. ' +
+    'Если ничего не подходит, ответь "default".\n\n' +
+    JSON.stringify(scenarios, null, 2);
+
+  const resp = await client.chat.completions.create({
+    model: 'gpt-4o-mini',
+    messages: [
+      { role: 'system', content: prompt },
+      { role: 'user', content: text }
+    ]
+  });
+
+  return resp.choices[0].message.content.trim();
+}
+
+function loadLoyaltyData(userId = 'default') {
+  const file = path.join('database', `loyalty_${userId}.json`);
+  let data;
+  try {
+    data = JSON.parse(fs.readFileSync(file, 'utf-8'));
+  } catch {
+    data = JSON.parse(fs.readFileSync(path.join('database', 'loyalty.json'), 'utf-8'));
+  }
+  return data;
+}
+
 app.post('/api/chat', async (req, res) => {
-  const { message } = req.body;
-  const scenario = matchScenario(message) || scenarios.find(s => s.name === 'default');
-  const prompt = scenario.script;
+  const { message, userId } = req.body;
+  let scenario;
+
+  try {
+    const name = await classifyScenario(message);
+    scenario = scenarios.find(s => s.name === name);
+  } catch (e) {
+    console.error('classification error', e);
+  }
+
+  if (!scenario) {
+    scenario = matchScenario(message);
+  }
+
+  if (!scenario) {
+    scenario = { name: 'default', script: 'Ты дружелюбный помощник интернет-магазина.' };
+  }
+
+  let systemPrompt = scenario.script;
+
+  if (scenario.name === 'bonusBalance') {
+    const data = loadLoyaltyData(userId);
+    const history = (data.history || [])
+      .map(h => {
+        if (h.event) {
+          return `${h.date}: ${h.event} (${h.points})`;
+        }
+        const sign = h.change > 0 ? '+' : '';
+        return `${h.date}: ${h.reason} (${sign}${h.change})`;
+      })
+      .join('\n');
+    systemPrompt =
+      `Данные пользователя:\n` +
+      `- Бонусный баланс: ${data.bonus_balance}\n` +
+      `- Кэшбек: ${data.cashback_available}\n` +
+      `- Уровень: ${data.loyalty_tier}\n` +
+      `- Последнее обновление: ${data.last_updated}\n` +
+      `- История: \n${history}\n` +
+      `\nИспользуй эти данные, чтобы ответить на вопрос пользователя.`;
+  }
 
   try {
     const completion = await client.chat.completions.create({
       model: 'gpt-4o-mini',
       messages: [
-        { role: 'system', content: prompt },
+        { role: 'system', content: systemPrompt },
         { role: 'user',   content: message }
       ]
     });
 
-    // ← вот исправление:
     const reply = completion.choices[0].message.content.trim();
 
     res.json({ reply, followUps: scenario.followUps || [] });


### PR DESCRIPTION
## Summary
- add personalized loyalty data and intent detection in the chat API
- include a mock user id on frontend calls
- update loyalty JSON schema
- detect intents with GPT using scenario JSON
- keep original bonus history while adding extra fields

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68583f370548832199ccd79478fd2e1a