### PR TITLE
Add promo code support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,7 @@
    node server.js
    ```
 4. Откройте `http://localhost:3000` в браузере.
+
+Сценарий `viewPromoCodes` использует данные из `database/promoCodes.json`,
+а `personalDiscounts` — персональные промокоды из
+`database/personalPromoCodes.json`.


### PR DESCRIPTION
## Summary
- show promo code data in chat
- show personal promo code data per user
- document promo code scenarios

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6858485073c48321b2ade26e0a0ed551